### PR TITLE
add utils to remember popup state

### DIFF
--- a/src/app/utils/popupUtils.ts
+++ b/src/app/utils/popupUtils.ts
@@ -1,0 +1,9 @@
+const TTM_HAS_SEEN_POPUP_KEY = 'ttm-has-seen-popup';
+
+export function hasSeenPopup(): boolean {
+  return localStorage.getItem(TTM_HAS_SEEN_POPUP_KEY) !== null;
+}
+
+export function rememberSeenPopup(): void {
+  localStorage.setItem(TTM_HAS_SEEN_POPUP_KEY, true);
+}


### PR DESCRIPTION
adds `utils/popupUtils` that exposes two functions to check the state of whether or not the popup was viewed

will expand on this more once we determine how we want to show the popup